### PR TITLE
specify scalaVersion globally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ import com.typesafe.sbt.SbtScalariform._
 
 val commonSettings = Seq(
   version := "0.1-SNAPSHOT",
-  scalaVersion := "2.11.8",
   organization := "io.swave",
+  scalaVersion := "2.11.8",
   homepage := Some(new URL("http://swave.io")),
   description := "A Reactive Streams implementation in Scala",
   startYear := Some(2016),
@@ -91,6 +91,7 @@ val logback                = "ch.qos.logback"             %   "logback-classic" 
 
 lazy val swave = project.in(file("."))
   .aggregate(benchmarks, examples, core, `core-tests`, testkit)
+  .settings(commonSettings: _*)
   .settings(noPublishingSettings: _*)
 
 lazy val benchmarks = project


### PR DESCRIPTION
From ensime:
[error] You have a different version of scala for your build (2.10.6) and benchmarks (2.11.8).
[error] It is highly likely that this is a mistake with your configuration.
[error] Please read https://github.com/ensime/ensime-sbt/issues/138